### PR TITLE
Use pre-configured modules instead of absolute paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ extended tight-binding semi-empirical program package
 from Stefan Grimme's group at the University of Bonn.
 
 It makes it unnecessary to set environment variables like 
-`OMP_NUM_THREADS`, `MKL_NUM_THREADS`, `OMP_STACKSIZE`, and `XTBHOME`. 
+`OMP_NUM_THREADS`, `MKL_NUM_THREADS`, `OMP_STACKSIZE`, and `XTBHOME` globally,
+for example via the `.bashrc`. 
 It also provides a mechanism to automatically trap the output
-that would normally go to standard out.
+that would normally go to standard out (i.e. the terminal).
 
 ## Installation
 
@@ -24,11 +25,21 @@ in the directories in following order:
 `scriptpath`, `\home\$USER`, and `$PWD`.
 If `.runxtbrc` is found, it won't look for `runxtb.rc`.
 The last one found will be used to set the (local) default parameters. 
-This gives the possibility that every user may configure local settings.
+This gives the possibility that every user may configure local settings,
+it also gives the possibilities to overwrite settings for one directory only.
 A summary of the settings to be used are given with the `-h` option.
 
 This directory is currently set up to find `runxtb.rc` and should test 
 sucessfully without any changes.
+
+## Updating
+
+Updating should be as easy as pulling the new version. 
+If the script has been configured with `.runxtbrc`, 
+a file that won't be overwritten via git, 
+then these settings should be reviewed.
+While I try to avoid renaming internal options, it sometimes is necessary.
+In any case, new feature may require new settings.
 
 ## Usage and options
 
@@ -39,7 +50,7 @@ runxtb.sh [script options] <coord_file> [xtb options]
 Any switches used will overwrite rc settings, 
 which take precedence over the built-in defaults.
 For the same options/ modes, only the last one will have an effect,
-e.g. specifying `-sSi` will run interactively.
+e.g. specifying `-sSi` will run interactively (immediately).
 
 The following script options are available:
 
@@ -52,7 +63,9 @@ The following script options are available:
               No output file will be created in interactive mode by default.
               In non-interactive mode it will be derived from the first argument given
               after the options, which should be `coord_file`.
- * `-s`       Write PBS submitscript instead of interactive execution.
+              The automatic generation of the file name can be triggered with `-o0`
+              or `-o auto`, and can be overwritten explicitly with `-c ''` (space is important).
+ * `-s`       Write a submitscript instead of interactive execution (PBS is default).
               This resulting file needs to be sumbitted separately, 
               which might be useful if review is necessary 
               (configuration option `run_interactive=no`).
@@ -60,12 +73,12 @@ The following script options are available:
               This also requires setting a queueing system with `-Q` (see below).
               (configuration option `run_interactive=sub`).
  * `-Q <ARG>` Set a queueing system for which the submitscript should be prepared.
-              Currently supported are `pbs-gen` and `bsub-rwth`.
-              (configuration option `request_qsys=<ARG>`)
- * `-P <ARG>` Accont to project `<ARG>`, which will also trigger
+              Currently supported are `pbs-gen`, `bsub-gen`, and `bsub-rwth` 
+              (configuration option `request_qsys=<ARG>`).
+ * `-P <ARG>` Accont to project `<ARG>`, which will also (currently) trigger
               `-Q bsub-rwth` to be set. It will not trigger `-s`/`-S`.
  * `-M`       Use preinstalled modules instead of paths. This is currently a work in progress.
-              This also needs a specified module or a list of modules, 
+              This option also needs a specified module or a list of modules, 
               which can be set with `-l <ARG>`(see below) or in the rc
               (configuration option `use_modules=true`).
  * `-l <ARG>` Specify a module to be used. This will also invoke `-M`.
@@ -79,6 +92,8 @@ The following script options are available:
  * `-B <ARG>` Set the absolute path to the executable `xtb` to `<ARG>`.
               The name of the program needs to be included.
               In the configuration file these are separated.
+ * `-C <ARG>` Set the name of the program directly.
+              This may be useful to access a different executeable from the package.
  * `-q`       Suppress any logging messages of the script.
               If specified twice, it will also suppress warnings,
               if specified more than twice, it will suppress also errors.
@@ -114,4 +129,4 @@ For example:
 runxtb.sh debug -p1 -qq -s  dummy.xyz -opt -gfn
 ```
 
-(Martin, 2018/04/27)
+(Martin, 2018/05/03)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ If the script has been configured with `.runxtbrc`,
 a file that won't be overwritten via git, 
 then these settings should be reviewed.
 While I try to avoid renaming internal options, it sometimes is necessary.
-In any case, new feature may require new settings.
+In any case, a new feature may require new settings;
+hence, this should also be checked.
 
 ## Usage and options
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ runxtb.sh [script options] <coord_file> [xtb options]
 Any switches used will overwrite rc settings, 
 which take precedence over the built-in defaults.
 For the same options/ modes, only the last one will have an effect,
-e.g. specifying `-sSi` wil run interactively.
+e.g. specifying `-sSi` will run interactively.
 
 The following script options are available:
 
@@ -64,6 +64,15 @@ The following script options are available:
               (configuration option `request_qsys=<ARG>`)
  * `-P <ARG>` Accont to project `<ARG>`, which will also trigger
               `-Q bsub-rwth` to be set. It will not trigger `-s`/`-S`.
+ * `-M`       Use preinstalled modules instead of paths. This is currently a work in progress.
+              This also needs a specified module or a list of modules, 
+              which can be set with `-l <ARG>`(see below) or in the rc
+              (configuration option `use_modules=true`).
+ * `-l <ARG>` Specify a module to be used. This will also invoke `-M`.
+              The option may be specified multiple times to create a list (stored as an array).
+              The modules need to be specified in the order they have to be loaded.
+              This can also be set in the rc 
+              (configuration option `load_modules[<N>]=<ARG>` with `<N>` being the integer load order).
  * `-i`       Execute in interactive mode. (Default without configuration.)
               This option is useful to overwrite rc settings
               (configuration option `run_interactive=yes`).
@@ -105,4 +114,4 @@ For example:
 runxtb.sh debug -p1 -qq -s  dummy.xyz -opt -gfn
 ```
 
-(Martin, 2018/04/12)
+(Martin, 2018/04/27)

--- a/runxtb.rc
+++ b/runxtb.rc
@@ -45,6 +45,16 @@
 #
    bsub_rwth_project="default"
 
+## If modules are installed, their use can be enabled here.
+## The default is setting the path, see above.
+#
+#  use_modules="true"
+#
+#  They need to be named, too. For example:
+#
+#  load_modules[0]="CHEMISTRY"
+#  load_modules[1]="xtb"
+
 ## Set Walltime for non-interactive mode
 #
 #  requested_walltime="24:00:00"

--- a/runxtb.rc
+++ b/runxtb.rc
@@ -1,4 +1,5 @@
-# Example .runxtbrc
+## Example .runxtbrc
+#
 
 ## Set default processes (= number of available cores)
 #
@@ -26,22 +27,33 @@
 #
    stay_quiet=0
 
-## Trap output of xtb in (default filename)
+## Trap output of xtb in a file.
+## Uncomment below to always use the same filename, 
+## which can be overwritten with the -o switch.
 #
 #  output_file="runxtb.out"
+#
+## Always generate a file with the output of xtb, but generate this name
+## automagically, arguments: 'auto' or '0'.
+#
+   output_file="auto"
+#
+## This can be overwritten with an explicit empty argument to -c:
+##   runxtb -c '' [other opts] <coord> [xtb options]
 
-## Set default mode 
+## Set default mode, where interactive means that it is calculated immediately.
 ## (yes: interactive; no: write script; sub: write and submit)
 #
    run_interactive="yes"
 
 ## Set default queueing system for which the script should be written
-## (pbs-gen, or bsub-rwth)
+## (pbs-gen, bsub-gen, or bsub-rwth [special case, see source)
 #
    request_qsys="bsub-rwth"
 
-## If project options are enabled (i.e. for bsub-rwth), 
-## set to which it should be accounted
+## If project options are enabled (e.g. for bsub-rwth), 
+## set to which it should be accounted.
+## This can be overwritten with -P0 or -P default.
 #
    bsub_project="default"
 
@@ -59,3 +71,5 @@
 #
 #  requested_walltime="24:00:00"
 
+#
+## End of example .runxtbrc (2018-05-03)

--- a/runxtb.rc
+++ b/runxtb.rc
@@ -43,7 +43,7 @@
 ## If project options are enabled (i.e. for bsub-rwth), 
 ## set to which it should be accounted
 #
-   bsub_rwth_project="default"
+   bsub_project="default"
 
 ## If modules are installed, their use can be enabled here.
 ## The default is setting the path, see above.

--- a/runxtb.sh
+++ b/runxtb.sh
@@ -340,8 +340,23 @@ write_submit_script ()
 
 		cd "$PWD"
 		
-		export PATH="\$PATH:$XTBHOME"
-		export XTBHOME="$XTBHOME" 
+		EOF
+
+    if [[ "$use_modules" =~ ^[Tt][Rr]?[Uu]?[Ee]? ]] ; then
+      (( ${#load_modules[*]} == 0 )) && fatal "No modules to load."
+      cat >&9 <<-EOF
+			# Loading the modules should take care of everything except threats
+			modules load ${load_modules[*]}
+			 
+			EOF
+    else
+    	cat >&9 <<-EOF
+			export PATH="\$PATH:$XTBHOME"
+			export XTBHOME="$XTBHOME" 
+			EOF
+    fi
+
+    cat >&9 <<-EOF
 		export OMP_NUM_THREADS="$OMP_NUM_THREADS"
 		export MKL_NUM_THREADS="$MKL_NUM_THREADS"
 		export OMP_STACKSIZE="${OMP_STACKSIZE}m"  
@@ -391,7 +406,10 @@ run_interactive="yes"
 request_qsys="pbs-gen"
 bsub_rwth_project="default"
 exit_status=0
-
+use_modules="false"
+declare -a load_modules
+#load_modules[0]="CHEMISTRY"
+#load_modules[1]="xtb"
 stay_quiet=0
 
 if [[ "$1" == "debug" ]] ; then
@@ -452,6 +470,10 @@ while getopts :p:m:w:o:sSQ:P:iB:qhH options ; do
     #hlp            (It will not trigger remote execution.)
     P) bsub_rwth_project="$OPTARG"
        request_qsys="bsub-rwth"
+       ;;
+    #hlp   -M       Use modules instead of paths (work in progress).
+    #hlp            Needs a specified modules list (set in rc).
+    M) use_modules=true
        ;;
     #hlp   -i       Execute in interactive mode (overwrite rc settings)
     i) run_interactive="yes"

--- a/runxtb.sh
+++ b/runxtb.sh
@@ -327,7 +327,11 @@ write_submit_script ()
 			#BSUB -o $submitscript_filename.o%J
 			#BSUB -e $submitscript_filename.e%J
 			EOF
-      if [[ ! -z $bsub_project ]] ; then
+      # If 'bsub_project' is empty, or '0', or 'default' (in any case, truncated after def)
+      # do not write this line to the script.
+      if [[ "$bsub_project" =~ ^(|0|[Dd][Ee][Ff][Aa]?[Uu]?[Ll]?[Tt]?)$ ]] ; then
+        message "No project selected."
+      else
         echo "#BSUB -P $bsub_project" >&9
       fi
       #add some more specific setup for RWTH
@@ -588,6 +592,7 @@ if [[ $run_interactive =~ ([Nn][Oo]|[Ss][Uu][Bb]) ]] ; then
     fi
     if (( exit_status > 0 )) ; then
       warning "Submission went wrong."
+      warning "Probable cause: $submit_id"
     else
       message "$submit_id"
     fi
@@ -597,6 +602,12 @@ if [[ $run_interactive =~ ([Nn][Oo]|[Ss][Uu][Bb]) ]] ; then
 elif [[ $run_interactive == "yes" ]] ; then
   if [[ -z $output_file ]] ; then 
     $xtb_callname "${xtb_commands[@]}" 
+    exit_status="$?" # Carry over exit status
+  elif [[ "$output_file" =~ ^(0|[Aa][Uu][Tt][Oo])$ ]] ; then
+    # Enables automatic generation of output-filename in 'interactive' mode
+    output_file="$jobname.runxtb.out"
+    backup_if_exists "$output_file"
+    $xtb_callname "${xtb_commands[@]}" > "$output_file"
     exit_status="$?" # Carry over exit status
   else
     backup_if_exists "$output_file"


### PR DESCRIPTION
On a cluster/computer that uses modular software management, it is possible to access these pre-configured installations via the script. This requires configuration or setting them as command line flags.

Implements the automatic generation of the file name where the xtb output shall be trapped, i.e. https://github.com/polyluxus/runxtb.bash/issues/12

If the project is set to `0` or `default`, it will be silently ignored. (This might cause problems, if there actually is a project called default.)

Different executable files from xtb can be accessed directly via `-C <ARG>`, e.g. `rmatom`.