### PR TITLE
Rwth module update

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ Alternative options (e.g. `'scriptpath'/.runxtbrc`) are also given.
 After that, the configuration script will ask about creating symbolic links in `~/bin`.
 If you choose to do that, you can basically access the script from anywhere in your file system.
 
+### Pointer for modules on Claix18 as of 15.11.2023
+You need the following modules in the `.runxtbrc` file:
+```
+load_modules[0]="foss/2022a"
+load_modules[1]="xtb/6.5.1"
+load_modules[2]="CREST/2.12"
+```
+The script will determine if you are on an RWTH cluster and unload the `intel` toolchain
+automatically, as you are otherwise not able to load the `OpenMPI` module which is part of the
+    `foss/2022a` toolchain. More information can be found [here.](https://help.itc.rwth-aachen.de/service/rhr4fjjutttf/article/450d33cc19fd4e50b1dd07027e9b55bd/#user-content-toolchains)
+
 ## Updating
 
 If you decided to clone the repository, make sure to stash your changes,

--- a/runxtb.sh
+++ b/runxtb.sh
@@ -638,7 +638,9 @@ write_submit_script ()
 			# Export current (at the time of execution) MODULEPATH (to be safe, could be set in bashrc)
 			export MODULEPATH="$MODULEPATH"
 			EOF
-
+      if [[ "$queue" =~ [Rr][Ww][Tt][Hh] ]] ; then
+        echo "module unload intel" >&9
+      fi
       for mod in "${load_modules[@]}" ; do
         cat >&9 <<-EOF
 				module load "${mod}"

--- a/runxtb.sh
+++ b/runxtb.sh
@@ -367,7 +367,7 @@ load_xtb_modules ()
   # Also checks if on RWTH cluster as the intel toolchain as to be unloaded before the foss
   # toolchain can be loaded without throwing errors.
   if [[ $(uname -n) == *"rwth"* ]]; then
-    module unload intel
+    module unload intel &>> "$tmpfile"
   fi
 
   for mod in "${load_modules[@]}" ; do

--- a/runxtb.sh
+++ b/runxtb.sh
@@ -631,11 +631,17 @@ write_submit_script ()
 			# Loading the modules should take care of everything except threads
 			# Export current (at the time of execution) MODULEPATH (to be safe, could be set in bashrc)
 			export MODULEPATH="$MODULEPATH"
-			module load ${load_modules[*]} 2>&1 || exit 1
+			EOF
+
+      for mod in "${load_modules[@]}" ; do
+        cat >&9 <<-EOF
+				module load "${mod}"
+				EOF
+      done
+
 			# Redirect because otherwise it would go to the error output, which might be bad
 			# Exit on error, which it might not do given a specific implementation
 			 
-			EOF
     else
       # Use path settings
       # exported in wrapper: XTBHOME XTBPATH PATH MANPATH LD_LIBRARY_PATH PYTHONPATH

--- a/runxtb.sh
+++ b/runxtb.sh
@@ -364,6 +364,12 @@ load_xtb_modules ()
   # Exit if that fails (On RWTH cluster the exit status of modules is always 0).
   # The new Lmod module system throws errors when loading all modules sequentially in one
   # command, thus they are now loaded sequentially.
+  # Also checks if on RWTH cluster as the intel toolchain as to be unloaded before the foss
+  # toolchain can be loaded without throwing errors.
+  if [[ $(uname -n) == *"rwth"* ]]; then
+    module unload intel
+  fi
+
   for mod in "${load_modules[@]}" ; do
     module load "${mod}" &>> "$tmpfile" || fatal "Failed to load module."
   done


### PR DESCRIPTION
At RWTH's claix18 a new module system has been introduced, therefore modules cannot be loaded in a single command anymore. Hence, module loading is switched to sequentially run "module load" commands over the array of modules. In addition, per default intel toolchains are loaded which conflict with the need of OpenMPI for xtb. Therefore, if the program is run on RWTH's claix18 the intel toolchain is unloaded before starting to load the modules.  Changes have been made for both local and batch jobs.